### PR TITLE
"Fixes" character encoding bug

### DIFF
--- a/src/main/java/inflectra/idea/core/listeners/TreeListener.java
+++ b/src/main/java/inflectra/idea/core/listeners/TreeListener.java
@@ -30,8 +30,11 @@ import java.awt.event.MouseListener;
  * @author Peter Geertsema
  */
 public class TreeListener implements MouseListener {
-  private static String expandButton = "▶ ";
-  private static String collapseButton = "▼ ";
+  //These characters use UTF-8, java isn't loading the plugin as that for some reason
+  //private static String expandButton = "▶ ";
+  //private static String collapseButton = "▼ ";
+  private static String expandButton = "+ ";
+  private static String collapseButton = "- ";
   JBPanel panel;
   JBLabel label;
   boolean isExpanded = false;
@@ -43,7 +46,7 @@ public class TreeListener implements MouseListener {
     String text = label.getText();
     int startLoc = text.indexOf("<h2>") + 4;
     //add in the expand button, which is smaller than the rest of the text
-    text = text.substring(0, startLoc) + "<span style=\"font-size: .6em; font-family: Arial\">" + expandButton + "</span>" + text.substring(startLoc);
+    text = text.substring(0, startLoc) + "<span style=\"font-size: 1em; font-family: Arial\">" + expandButton + "</span>" + text.substring(startLoc);
     label.setText(text);
     //make the header color inactive by default
     Color color = UIUtil.getHeaderInactiveColor();

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <idea-plugin>
     <id>com.inflectra.SpiraTeam</id>
     <name>SpiraPlan Integration</name>
@@ -10,7 +11,7 @@
 
     <change-notes><![CDATA[
       <ul>
-        <li>Updated Plugin to be compatible with 2020+ JetBrains Products</li>
+        <li>Updated Plugin to be compatible with 2022 JetBrains Products</li>
       </ul>
 
     ]]>


### PR DESCRIPTION
This "fixes" the character encoding bug introduced in the migration to a Gradle plugin, by replacing the special characters with plus and minus signs. This is not a great fix because it changes the UI, but this means when updating the plugin in the future we would not run into this issue again.

The issue we're having is caused by the fact that Java is using the default system charset, windows-1252, when printing the text to the window. Even after trying to change the file encoding with an environment variable when building and running the plugin, I had no luck. If anyone else would like to try to solve this, I suggest starting here: https://stackoverflow.com/questions/361975/setting-the-default-java-character-encoding 